### PR TITLE
Add new workflows and actions to Fortinet package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,4 +7,5 @@ Initial Revision
 ##  V0.0.2
 
 Create Firewall actions create_fortinet_policy and delete_fortinet_policy for older FortiManager and FortiGates version
-Create two Workflows create_policy and delete_policy for XMC Integration.
+Create two Workflows create_policy and delete_policy for ST2 XMC Integration version 8.2.1.
+Create two Rules create_policy and delete_policy for ST2 XMC Integration version 8.1.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,3 +3,8 @@
 ## v0.0.1
 
 Initial Revision
+
+##  V0.0.2
+
+Create Firewall actions create_fortinet_policy and delete_fortinet_policy for older FortiManager and FortiGates version
+Create two Workflows create_policy and delete_policy for XMC Integration.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The following actions are supported:
 * ``get_firewall_policy``
 * ``move_firewall_policy``
 * ``update_firewall_policy``
+* ``create_fortinet_policy``
+* ``delete_fortinet_policy``
  
 ### Address Object:
 * ``create_address_object``

--- a/actions/create_fortinet_policy.py
+++ b/actions/create_fortinet_policy.py
@@ -7,7 +7,7 @@ class CreateAddressGroup(FortinetBaseAction):
     def run(self, threat_ip=None):
         status = self.san_device.add_threat(threat_ip)
         
-        if status != None:
+        if status is not None:
             result = json.loads(status)
             data = result['result'][0]
             if data['status']['code'] == 0:

--- a/actions/create_fortinet_policy.py
+++ b/actions/create_fortinet_policy.py
@@ -1,0 +1,15 @@
+import json
+
+from lib.action import FortinetBaseAction
+
+
+class CreateAddressGroup(FortinetBaseAction):
+    def run(self, threat_ip=None):
+        status = self.san_device.add_threat(threat_ip)
+        
+        if status != None:
+            result = json.loads(status)
+            data = result['result'][0]
+            if data['status']['code'] == 0:
+                return (True, status)
+        return (False, status)

--- a/actions/create_fortinet_policy.py
+++ b/actions/create_fortinet_policy.py
@@ -1,11 +1,11 @@
 import json
 
-from lib.san_action import FortinetBaseAction
+from lib.san_action import SanFortinetBaseAction
 
 
-class CreateAddressGroup(FortinetBaseAction):
+class CreateAddressGroup(SanFortinetBaseAction):
     def run(self, threat_ip=None):
-        status = self.device.add_threat(threat_ip)
+        status = self.san_device.add_threat(threat_ip)
 
         if status is not None:
             result = json.loads(status)

--- a/actions/create_fortinet_policy.py
+++ b/actions/create_fortinet_policy.py
@@ -1,11 +1,11 @@
 import json
 
-from lib.action import FortinetBaseAction
+from lib.san_action import FortinetBaseAction
 
 
 class CreateAddressGroup(FortinetBaseAction):
     def run(self, threat_ip=None):
-        status = self.device.add_threat(threat_ip, True)
+        status = self.device.add_threat(threat_ip)
 
         if status is not None:
             result = json.loads(status)

--- a/actions/create_fortinet_policy.py
+++ b/actions/create_fortinet_policy.py
@@ -6,10 +6,10 @@ from lib.action import FortinetBaseAction
 class CreateAddressGroup(FortinetBaseAction):
     def run(self, threat_ip=None):
         status = self.san_device.add_threat(threat_ip)
-        
+
         if status is not None:
             result = json.loads(status)
             data = result['result'][0]
             if data['status']['code'] == 0:
-                return (True, status)
-        return (False, status)
+                return True, status
+        return False, status

--- a/actions/create_fortinet_policy.py
+++ b/actions/create_fortinet_policy.py
@@ -5,7 +5,7 @@ from lib.action import FortinetBaseAction
 
 class CreateAddressGroup(FortinetBaseAction):
     def run(self, threat_ip=None):
-        status = self.san_device.add_threat(threat_ip)
+        status = self.device.add_threat(threat_ip, True)
 
         if status is not None:
             result = json.loads(status)

--- a/actions/create_fortinet_policy.yaml
+++ b/actions/create_fortinet_policy.yaml
@@ -1,0 +1,11 @@
+name: create_fortinet_policy
+pack: fortinet
+runner_type: python-script
+description: "Create Fortinet Policy"
+enabled: true
+entry_point: "create_fortinet_policy.py"
+parameters:
+    threat_ip:
+        type: "string" 
+        description: "Threat IP address that is going to be blocked"
+        required: True

--- a/actions/create_policy.yaml
+++ b/actions/create_policy.yaml
@@ -1,0 +1,14 @@
+---
+name: create_policy
+pack: fortinet
+runner_type: "mistral-v2"
+description: Add thread IP to policy table
+enabled: true
+entry_point: workflows/create_policy.meta.yaml
+
+parameters:
+    threat_ip:
+        type: "string" 
+        description: "Threat IP address that is going to be blocked"
+        required: True
+        

--- a/actions/delete_fortinet_policy.py
+++ b/actions/delete_fortinet_policy.py
@@ -1,11 +1,11 @@
 import json
 
-from lib.san_action import FortinetBaseAction
+from lib.san_action import SanFortinetBaseAction
 
 
-class DeleteAddressGroup(FortinetBaseAction):
+class DeleteAddressGroup(SanFortinetBaseAction):
     def run(self, threat_ip=None):
-        status = self.device.remove_threat(threat_ip)
+        status = self.san_device.remove_threat(threat_ip)
 
         if status is not None:
             result = json.loads(status)

--- a/actions/delete_fortinet_policy.py
+++ b/actions/delete_fortinet_policy.py
@@ -5,7 +5,7 @@ from lib.action import FortinetBaseAction
 
 class DeleteAddressGroup(FortinetBaseAction):
     def run(self, threat_ip=None):
-        status = self.san_device.remove_threat(threat_ip)
+        status = self.device.remove_threat(threat_ip, True)
 
         if status is not None:
             result = json.loads(status)

--- a/actions/delete_fortinet_policy.py
+++ b/actions/delete_fortinet_policy.py
@@ -1,0 +1,15 @@
+import json
+
+from lib.action import FortinetBaseAction
+
+
+class DeleteAddressGroup(FortinetBaseAction):
+    def run(self, threat_ip=None):
+        status = self.san_device.remove_threat(threat_ip)
+
+        if status != None:
+            result = json.loads(status)
+            data = result['result'][0]
+            if data['status']['code'] == 0:
+                return (True, status)
+        return (False, status)

--- a/actions/delete_fortinet_policy.py
+++ b/actions/delete_fortinet_policy.py
@@ -7,7 +7,7 @@ class DeleteAddressGroup(FortinetBaseAction):
     def run(self, threat_ip=None):
         status = self.san_device.remove_threat(threat_ip)
 
-        if status != None:
+        if status is not None:
             result = json.loads(status)
             data = result['result'][0]
             if data['status']['code'] == 0:

--- a/actions/delete_fortinet_policy.py
+++ b/actions/delete_fortinet_policy.py
@@ -1,11 +1,11 @@
 import json
 
-from lib.action import FortinetBaseAction
+from lib.san_action import FortinetBaseAction
 
 
 class DeleteAddressGroup(FortinetBaseAction):
     def run(self, threat_ip=None):
-        status = self.device.remove_threat(threat_ip, True)
+        status = self.device.remove_threat(threat_ip)
 
         if status is not None:
             result = json.loads(status)

--- a/actions/delete_fortinet_policy.py
+++ b/actions/delete_fortinet_policy.py
@@ -11,5 +11,5 @@ class DeleteAddressGroup(FortinetBaseAction):
             result = json.loads(status)
             data = result['result'][0]
             if data['status']['code'] == 0:
-                return (True, status)
-        return (False, status)
+                return True, status
+        return False, status

--- a/actions/delete_fortinet_policy.yaml
+++ b/actions/delete_fortinet_policy.yaml
@@ -1,0 +1,11 @@
+name: delete_fortinet_policy
+pack: fortinet
+runner_type: python-script
+description: "Delete Fortinet Policy"
+enabled: true
+entry_point: "delete_fortinet_policy.py"
+parameters:
+    threat_ip:
+        type: "string" 
+        description: "Threat IP address that is going to be deleted."
+        required: True

--- a/actions/delete_policy.yaml
+++ b/actions/delete_policy.yaml
@@ -1,0 +1,14 @@
+---
+name: delete_policy
+pack: fortinet
+runner_type: "mistral-v2"
+description: Delete thread IP from policy table
+enabled: true
+entry_point: workflows/delete_policy.meta.yaml
+
+parameters:
+    threat_ip:
+        type: "string" 
+        description: "Threat IP address that is going to be deleted"
+        required: True
+        

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -5,13 +5,15 @@ from fortinet_policy import FortinetApi
 
 
 class FortinetBaseAction(Action):
-    def __init__(self, config):
+    def __init__(self, config, is_old_version=False):
         super(FortinetBaseAction, self).__init__(config)
         self._firewall_ip = self.config['firewall_ip']
         self._username = self.config['username']
         self._password = self.config['password']
-        self.device = self.fortinet_device()
-        self.san_device = self.san_device()
+        if is_old_version:
+            self.device = self.san_device()
+        else:
+            self.device = self.fortinet_device()
 
     def fortinet_device(self):
         device = pyfortiapi.FortiGate(ipaddr=self._firewall_ip, username=self._username,

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -3,6 +3,7 @@ from st2common.runners.base_action import Action
 
 from fortinet_policy import FortinetApi
 
+
 class FortinetBaseAction(Action):
     def __init__(self, config):
         super(FortinetBaseAction, self).__init__(config)
@@ -16,8 +17,9 @@ class FortinetBaseAction(Action):
         device = pyfortiapi.FortiGate(ipaddr=self._firewall_ip, username=self._username,
                                       password=self._password)
         return device
-      
+
     def san_device(self):
-        san_device = FortinetApi(fortinet=self._firewall_ip, username=self._username, password=self._password)
+        san_device = FortinetApi(fortinet=self._firewall_ip, username=self._username,
+                                 password=self._password)
 
         return san_device

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -1,6 +1,7 @@
 import pyfortiapi
 from st2common.runners.base_action import Action
 
+from fortinet_policy import FortinetApi
 
 class FortinetBaseAction(Action):
     def __init__(self, config):
@@ -9,8 +10,14 @@ class FortinetBaseAction(Action):
         self._username = self.config['username']
         self._password = self.config['password']
         self.device = self.fortinet_device()
+        self.san_device = self.san_device()
 
     def fortinet_device(self):
         device = pyfortiapi.FortiGate(ipaddr=self._firewall_ip, username=self._username,
                                       password=self._password)
         return device
+      
+    def san_device(self):
+        san_device = FortinetApi(fortinet=self._firewall_ip, username=self._username, password=self._password)
+
+        return san_device

--- a/actions/lib/fortinet_policy.py
+++ b/actions/lib/fortinet_policy.py
@@ -76,7 +76,8 @@ class FortinetApi(object):
         groups = None
         session = self.get_session_id()
         id = self.get_random_id()
-        data = {"params": [{"url": "pm/config/adom/root/obj/firewall/addrgrp"}], "session": session, "id": id, "method": "get"}
+        data = {"params": [{"url": "pm/config/adom/root/obj/firewall/addrgrp"}],
+                "session": session, "id": id, "method": "get"}
         content = self.post(data)
         if content is not None and 'data' in content:
             j = json.loads(content)
@@ -88,13 +89,19 @@ class FortinetApi(object):
     def add_address_group(self, group, members):
         session = self.get_session_id()
         id = self.get_random_id()
-        data = {"params": [{"url": "pm/config/adom/root/obj/firewall/addrgrp", "data": [{"color": 13, "visbility": "enable", "comment": "", "name": group, "member": members}]}], "session": session, "id": id, "method": "add"}
+        data = {"params": [{"url": "pm/config/adom/root/obj/firewall/addrgrp",
+                            "data": [{"color": 13, "visbility": "enable", "comment": "",
+                                      "name": group, "member": members}]}],
+                "session": session, "id": id, "method": "add"}
         return self.post(data)
 
     def update_group(self, group, members):
         session = self.get_session_id()
         id = self.get_random_id()
-        data = {"params": [{"url": "pm/config/adom/root/obj/firewall/addrgrp", "data": [{"color": 13, "visbility": "enable", "comment": "", "name": group, "member": members}]}], "session": session, "id": id, "method": "update"}
+        data = {"params": [{"url": "pm/config/adom/root/obj/firewall/addrgrp",
+                            "data": [{"color": 13, "visbility": "enable", "comment": "",
+                                      "name": group, "member": members}]}], "session": session,
+                "id": id, "method": "update"}
         return self.post(data)
 
     def get_policy_packages(self):
@@ -125,20 +132,35 @@ class FortinetApi(object):
             policies = data['data']
         return policies
 
-    def add_deny_sip_policy(self, package, name, srcAddressGroup, srcInterface=['any'], dstAddressGroup=['all'], dstInterface=['any'], comments='json web service rule'):
-        return self.add_deny_policy(package, name, [srcAddressGroup], srcInterface, dstAddressGroup, dstInterface, comments)
+    def add_deny_sip_policy(self, package, name, srcAddressGroup, srcInterface=['any'],
+                            dstAddressGroup=['all'], dstInterface=['any'],
+                            comments='json web service rule'):
+        return self.add_deny_policy(package, name, [srcAddressGroup], srcInterface,
+                                    dstAddressGroup, dstInterface, comments)
 
-    def add_deny_dip_policy(self, package, name, dstAddressGroup, dstInterface=['any'], srcAddressGroup=['all'], srcInterface=['any'], comments='json web service rule'):
-        return self.add_deny_policy(package, name, srcAddressGroup, srcInterface, [dstAddressGroup], dstInterface, comments)
+    def add_deny_dip_policy(self, package, name, dstAddressGroup, dstInterface=['any'],
+                            srcAddressGroup=['all'], srcInterface=['any'],
+                            comments='json web service rule'):
+        return self.add_deny_policy(package, name, srcAddressGroup, srcInterface,
+                                    [dstAddressGroup], dstInterface, comments)
 
-    def add_deny_policy(self, package, name, srcAddressGroup, srcInterface, dstAddressGroup, dstInterface, comments):
+    def add_deny_policy(self, package, name, srcAddressGroup, srcInterface, dstAddressGroup,
+                        dstInterface, comments):
         session = self.get_session_id()
         id = self.get_random_id()
         url = 'pm/config/adom/root/pkg/{0}/firewall/policy'.format(package)
         data = {"params": [{"url": url,
-                            "data": [{"action": "deny", "comments": comments, "dstaddr": dstAddressGroup, "dstintf": dstInterface,
-                                      "global-label": name, "ippool": "enable", "logtraffic": "disable", "nat": "disable",
-                                      "schedule": ["always"], "service": ["ALL"], "srcaddr": srcAddressGroup, "srcintf": srcInterface,
+                            "data": [{"action": "deny", "comments": comments,
+                                      "dstaddr": dstAddressGroup,
+                                      "dstintf": dstInterface,
+                                      "global-label": name,
+                                      "ippool": "enable",
+                                      "logtraffic": "disable",
+                                      "nat": "disable",
+                                      "schedule": ["always"],
+                                      "service": ["ALL"],
+                                      "srcaddr": srcAddressGroup,
+                                      "srcintf": srcInterface,
                                       "status": "enable"}]}],
                 "session": session, "id": id, "method": "add"}
         return self.post(data)
@@ -147,7 +169,8 @@ class FortinetApi(object):
         status = None
         if self.session is not None:
             id = self.get_random_id()
-            data = {"verbose": 1, "params": [{"url": "sys/logout"}], "session": self.session, "id": id, "method": "exec"}
+            data = {"verbose": 1, "params": [{"url": "sys/logout"}], "session": self.session,
+                    "id": id, "method": "exec"}
             status = self.post(data)
         return status
 
@@ -257,7 +280,8 @@ class FortinetApi(object):
                             print 'Creating address object for: {0}'.format(placeholder)
                             self.add_address(placeholder)
 
-                        print 'Removing threat: {0} from group: {1}, adding: {2} to prevent an error'.format(threat, group, placeholder)
+                        print 'Removing threat: {0} from group: {1}, adding: {2} to prevent an ' \
+                              'error'.format(threat, group, placeholder)
                         status = self.update_group(group, [placeholder])
                         self.delete_address(threat)
                 else:
@@ -276,8 +300,8 @@ if __name__ == "__main__":
     password = ''
     threat = '192.168.10.5'
     api = FortinetApi(fortimanager, username, password)
-    #status = api.add_threat(threat)
-    #print status
-    #status = api.remove_threat(threat)
-    #print status
+    status = api.add_threat(threat)
+    print status
+    status = api.remove_threat(threat)
+    print status
     api.logout()

--- a/actions/lib/fortinet_policy.py
+++ b/actions/lib/fortinet_policy.py
@@ -3,6 +3,7 @@ import random
 import requests
 import urllib3
 
+
 class FortinetApi(object):
     def __init__(self, fortinet, username, password):
         self.fortinet = fortinet
@@ -13,9 +14,12 @@ class FortinetApi(object):
     def get_session_id(self):
         if self.session is None:
             id = self.get_random_id()
-            data = {"params": [{"url": "sys/login/user", "data": [{"user": self.username, "passwd": self.password}]}], "session": 1, "id": id, "method": "exec"}
+            data = {"params": [{"url": "sys/login/user",
+                                "data": [{"user": self.username,
+                                          "passwd": self.password}]}],
+                    "session": 1, "id": id, "method": "exec"}
             content = self.post(data)
-            if content != None and 'session' in content:
+            if content is not None and 'session' in content:
                 response = json.loads(content)
                 self.session = response['session']
         return self.session
@@ -24,7 +28,8 @@ class FortinetApi(object):
         devices = None
         session = self.get_session_id()
         id = self.get_random_id()
-        data = {"params": [{"url": "dvmdb/device"}], "session": session, "id": id, "method": "get"}
+        data = {"params": [{"url": "dvmdb/device"}],
+                "session": session, "id": id, "method": "get"}
         content = self.post(data)
         if content is not None and 'data' in content:
             j = json.loads(content)
@@ -37,7 +42,9 @@ class FortinetApi(object):
         addresses = None
         session = self.get_session_id()
         id = self.get_random_id()
-        data = {"params": [{"url": "pm/config/adom/root/obj/firewall/address"}], "session": session, "id": id, "method": "get"}
+        data = \
+            {"params": [{"url": "pm/config/adom/root/obj/firewall/address"}],
+                "session": session, "id": id, "method": "get"}
         content = self.post(data)
         if content is not None and 'data' in content:
             j = json.loads(content)
@@ -49,14 +56,20 @@ class FortinetApi(object):
     def add_address(self, ipAddress):
         session = self.get_session_id()
         id = self.get_random_id()
-        data = {"params": [{"url": "pm/config/adom/root/obj/firewall/address", "data": [{"color": 13, "name": ipAddress, "type": 0, "associated-interface": "any", "subnet": [ipAddress, "255.255.255.255"]}]}], "session": session, "id": id, "method": "add"}
+        data = {"params": [{"url": "pm/config/adom/root/obj/firewall/address",
+                            "data": [{"color": 13, "name": ipAddress,
+                                      "type": 0, "associated-interface": "any",
+                                      "subnet": [ipAddress, "255.255.255.255"]
+                                      }]}], "session": session, "id": id,
+                "method": "add"}
         return self.post(data)
 
     def delete_address(self, ipAddress):
         session = self.get_session_id()
         id = self.get_random_id()
         url = 'pm/config/adom/root/obj/firewall/address/{0}'.format(ipAddress)
-        data = {"params":[{"url": url}], "session": session, "id": id, "method": "delete"}
+        data = {"params": [{"url": url}], "session": session,
+                "id": id, "method": "delete"}
         return self.post(data)
 
     def get_address_groups(self):
@@ -253,6 +266,7 @@ class FortinetApi(object):
                     status = self.update_group(group, members)
                     self.delete_address(threat)
         return status
+
 
 urllib3.disable_warnings()
 

--- a/actions/lib/fortinet_policy.py
+++ b/actions/lib/fortinet_policy.py
@@ -286,9 +286,10 @@ class FortinetApi(object):
                         self.delete_address(threat)
                 else:
                     print 'Removing threat: {0} from group: {1}'.format(threat, group)
-                    members.remove(threat)
-                    status = self.update_group(group, members)
-                    self.delete_address(threat)
+                    if threat in members:
+                        members.remove(threat)
+                        status = self.update_group(group, members)
+                        self.delete_address(threat)
         return status
 
 

--- a/actions/lib/fortinet_policy.py
+++ b/actions/lib/fortinet_policy.py
@@ -1,0 +1,269 @@
+import json
+import random
+import requests
+import urllib3
+
+class FortinetApi(object):
+    def __init__(self, fortinet, username, password):
+        self.fortinet = fortinet
+        self.username = username
+        self.password = password
+        self.session = None
+
+    def get_session_id(self):
+        if self.session is None:
+            id = self.get_random_id()
+            data = {"params": [{"url": "sys/login/user", "data": [{"user": self.username, "passwd": self.password}]}], "session": 1, "id": id, "method": "exec"}
+            content = self.post(data)
+            if content != None and 'session' in content:
+                response = json.loads(content)
+                self.session = response['session']
+        return self.session
+
+    def get_managed_devices(self):
+        devices = None
+        session = self.get_session_id()
+        id = self.get_random_id()
+        data = {"params": [{"url": "dvmdb/device"}], "session": session, "id": id, "method": "get"}
+        content = self.post(data)
+        if content is not None and 'data' in content:
+            j = json.loads(content)
+            result = j['result']
+            data = result[0]
+            devices = data['data']
+        return devices
+
+    def get_addresses(self):
+        addresses = None
+        session = self.get_session_id()
+        id = self.get_random_id()
+        data = {"params": [{"url": "pm/config/adom/root/obj/firewall/address"}], "session": session, "id": id, "method": "get"}
+        content = self.post(data)
+        if content is not None and 'data' in content:
+            j = json.loads(content)
+            result = j['result']
+            data = result[0]
+            addresses = data['data']
+        return addresses
+
+    def add_address(self, ipAddress):
+        session = self.get_session_id()
+        id = self.get_random_id()
+        data = {"params": [{"url": "pm/config/adom/root/obj/firewall/address", "data": [{"color": 13, "name": ipAddress, "type": 0, "associated-interface": "any", "subnet": [ipAddress, "255.255.255.255"]}]}], "session": session, "id": id, "method": "add"}
+        return self.post(data)
+
+    def delete_address(self, ipAddress):
+        session = self.get_session_id()
+        id = self.get_random_id()
+        url = 'pm/config/adom/root/obj/firewall/address/{0}'.format(ipAddress)
+        data = {"params":[{"url": url}], "session": session, "id": id, "method": "delete"}
+        return self.post(data)
+
+    def get_address_groups(self):
+        groups = None
+        session = self.get_session_id()
+        id = self.get_random_id()
+        data = {"params": [{"url": "pm/config/adom/root/obj/firewall/addrgrp"}], "session": session, "id": id, "method": "get"}
+        content = self.post(data)
+        if content is not None and 'data' in content:
+            j = json.loads(content)
+            result = j['result']
+            data = result[0]
+            groups = data['data']
+        return groups
+
+    def add_address_group(self, group, members):
+        session = self.get_session_id()
+        id = self.get_random_id()
+        data = {"params": [{"url": "pm/config/adom/root/obj/firewall/addrgrp", "data": [{"color": 13, "visbility": "enable", "comment": "", "name": group, "member": members}]}], "session": session, "id": id, "method": "add"}
+        return self.post(data)
+
+    def update_group(self, group, members):
+        session = self.get_session_id()
+        id = self.get_random_id()
+        data = {"params": [{"url": "pm/config/adom/root/obj/firewall/addrgrp", "data": [{"color": 13, "visbility": "enable", "comment": "", "name": group, "member": members}]}], "session": session, "id": id, "method": "update"}
+        return self.post(data)
+
+    def get_policy_packages(self):
+        packages = None
+        session = self.get_session_id()
+        id = self.get_random_id()
+        url = 'pm/pkg/adom/root'
+        data = {"params": [{"url": url}], "session": session, "id": id, "method": "get"}
+        content = self.post(data)
+        if content is not None and 'data' in content:
+            j = json.loads(content)
+            result = j['result']
+            data = result[0]
+            packages = data['data']
+        return packages
+
+    def get_policies(self, package):
+        policies = None
+        session = self.get_session_id()
+        id = self.get_random_id()
+        url = 'pm/config/adom/root/pkg/{0}/firewall/policy'.format(package)
+        data = {"params": [{"url": url}], "session": session, "id": id, "method": "get"}
+        content = self.post(data)
+        if content is not None and 'data' in content:
+            j = json.loads(content)
+            result = j['result']
+            data = result[0]
+            policies = data['data']
+        return policies
+
+    def add_deny_sip_policy(self, package, name, srcAddressGroup, srcInterface=['any'], dstAddressGroup=['all'], dstInterface=['any'], comments='json web service rule'):
+        return self.add_deny_policy(package, name, [srcAddressGroup], srcInterface, dstAddressGroup, dstInterface, comments)
+
+    def add_deny_dip_policy(self, package, name, dstAddressGroup, dstInterface=['any'], srcAddressGroup=['all'], srcInterface=['any'], comments='json web service rule'):
+        return self.add_deny_policy(package, name, srcAddressGroup, srcInterface, [dstAddressGroup], dstInterface, comments)
+
+    def add_deny_policy(self, package, name, srcAddressGroup, srcInterface, dstAddressGroup, dstInterface, comments):
+        session = self.get_session_id()
+        id = self.get_random_id()
+        url = 'pm/config/adom/root/pkg/{0}/firewall/policy'.format(package)
+        data = {"params": [{"url": url,
+                            "data": [{"action": "deny", "comments": comments, "dstaddr": dstAddressGroup, "dstintf": dstInterface,
+                                      "global-label": name, "ippool": "enable", "logtraffic": "disable", "nat": "disable",
+                                      "schedule": ["always"], "service": ["ALL"], "srcaddr": srcAddressGroup, "srcintf": srcInterface,
+                                      "status": "enable"}]}],
+                "session": session, "id": id, "method": "add"}
+        return self.post(data)
+
+    def logout(self):
+        status = None
+        if self.session is not None:
+            id = self.get_random_id()
+            data = {"verbose": 1, "params": [{"url": "sys/logout"}], "session": self.session, "id": id, "method": "exec"}
+            status = self.post(data)
+        return status
+
+    def get_random_id(self):
+        return random.randint(1, 0xFFFF)
+
+    def post(self, data):
+        content = None
+        url = 'https://{0}/jsonrpc'.format(self.fortinet)
+        headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
+        r = requests.post(url, verify=False, headers=headers, json=data)
+        code = r.status_code
+        if code == 200:
+            content = r.content
+        else:
+            print '{0} -> {1}'.format(str(code), r.content)
+        return content
+
+    def add_threat(self, threat, group='Block IPs'):
+        status = None
+        session = self.get_session_id()
+        if session is not None:
+            add = True
+            addresses = self.get_addresses()
+            if addresses is not None:
+                for address in addresses:
+                    name = address['name']
+                    if name == threat:
+                        add = False
+                        break
+            if add:
+                print 'Creating address object for: {0}'.format(threat)
+                self.add_address(threat)
+
+            members = None
+            groups = self.get_address_groups()
+            if groups is not None:
+                for g in groups:
+                    name = g['name']
+                    if name == group:
+                        members = g['member']
+
+            if members is None:
+                placeholder = '127.0.0.1'
+                self.add_address(placeholder)
+                members = [placeholder, threat]
+                status = self.add_address_group(group, members)
+            else:
+                name = type(members).__name__
+                if name == 'unicode' or name == 'str':
+                    members = [members]
+                if threat not in members:
+                    print 'Adding address object: {0} to group: {1}'.format(threat, group)
+                    members.append(threat)
+                    status = self.update_group(group, members)
+
+            packages = self.get_policy_packages()
+            if packages is not None:
+                for package in packages:
+                    name = package['name']
+                    if name is not None:
+                        sip = True
+                        dip = True
+                        policies = self.get_policies(name)
+                        if policies is not None:
+                            for policy in policies:
+                                label = policy['global-label']
+                                if label == 'DENY SIP':
+                                    sip = False
+                                elif label == 'DENY DIP':
+                                    dip = False
+                            if sip:
+                                print 'Creating DENY SIP policy rule for: {0}'.format(name)
+                                self.add_deny_sip_policy(name, 'DENY SIP', group)
+                            if dip:
+                                print 'Creating DENY DIP policy rule for: {0}'.format(name)
+                                self.add_deny_dip_policy(name, 'DENY DIP', group)
+        else:
+            print 'Unable to authenticate user and generate session ID'
+        return status
+
+    def remove_threat(self, threat, group='Block IPs'):
+        status = None
+        session = self.get_session_id()
+        if session is not None:
+            members = None
+            groups = self.get_address_groups()
+            if groups is not None:
+                for g in groups:
+                    name = g['name']
+                    if name == group:
+                        members = g['member']
+            if members is not None:
+                name = type(members).__name__
+                if name == 'unicode' or name == 'str':
+                    if members == threat:
+                        placeholder = '127.0.0.1'
+                        add = True
+                        addresses = self.get_addresses()
+                        if addresses is not None:
+                            for address in addresses:
+                                name = address['name']
+                                if name == placeholder:
+                                    add = False
+                                    break
+                        if add:
+                            print 'Creating address object for: {0}'.format(placeholder)
+                            self.add_address(placeholder)
+
+                        print 'Removing threat: {0} from group: {1}, adding: {2} to prevent an error'.format(threat, group, placeholder)
+                        status = self.update_group(group, [placeholder])
+                        self.delete_address(threat)
+                else:
+                    print 'Removing threat: {0} from group: {1}'.format(threat, group)
+                    members.remove(threat)
+                    status = self.update_group(group, members)
+                    self.delete_address(threat)
+        return status
+
+urllib3.disable_warnings()
+
+if __name__ == "__main__":
+    fortimanager = '10.65.47.23'
+    username = 'admin'
+    password = ''
+    threat = '192.168.10.5'
+    api = FortinetApi(fortimanager, username, password)
+    #status = api.add_threat(threat)
+    #print status
+    #status = api.remove_threat(threat)
+    #print status
+    api.logout()

--- a/actions/lib/san_action.py
+++ b/actions/lib/san_action.py
@@ -1,5 +1,6 @@
-import pyfortiapi
 from st2common.runners.base_action import Action
+
+from fortinet_policy import FortinetApi
 
 
 class FortinetBaseAction(Action):
@@ -8,9 +9,10 @@ class FortinetBaseAction(Action):
         self._firewall_ip = self.config['firewall_ip']
         self._username = self.config['username']
         self._password = self.config['password']
-        self.device = self.fortinet_device()
+        self.device = self.device()
 
-    def fortinet_device(self):
-        device = pyfortiapi.FortiGate(ipaddr=self._firewall_ip, username=self._username,
-                                      password=self._password)
+    def device(self):
+        device = FortinetApi(fortinet=self._firewall_ip, username=self._username,
+                             password=self._password)
+
         return device

--- a/actions/lib/san_action.py
+++ b/actions/lib/san_action.py
@@ -3,13 +3,13 @@ from st2common.runners.base_action import Action
 from fortinet_policy import FortinetApi
 
 
-class FortinetBaseAction(Action):
+class SanFortinetBaseAction(Action):
     def __init__(self, config):
-        super(FortinetBaseAction, self).__init__(config)
+        super(SanFortinetBaseAction, self).__init__(config)
         self._firewall_ip = self.config['firewall_ip']
         self._username = self.config['username']
         self._password = self.config['password']
-        self.device = self.device()
+        self.san_device = self.device()
 
     def device(self):
         device = FortinetApi(fortinet=self._firewall_ip, username=self._username,

--- a/actions/workflows/create_policy.meta.yaml
+++ b/actions/workflows/create_policy.meta.yaml
@@ -1,0 +1,24 @@
+---
+version: '2.0'
+
+fortinet.create_policy:
+    input:
+        - threat_ip
+
+    tasks:
+        creat_policy:
+            action: fortinet.create_fortinet_policy
+            input:
+                threat_ip: '<% $.threat_ip %>'
+            on-success:
+                - success_msg
+            on-error:
+                - failure_msg
+        success_msg:
+            action: core.local
+            input: 
+                cmd: 'echo \"Successfully excuted action\"'
+        failure_msg:
+            action: core.local
+            input: 
+                cmd: 'echo \"Failed to excute action\"'

--- a/actions/workflows/create_policy.meta.yaml
+++ b/actions/workflows/create_policy.meta.yaml
@@ -6,7 +6,7 @@ fortinet.create_policy:
         - threat_ip
 
     tasks:
-        creat_policy:
+        create_policy:
             action: fortinet.create_fortinet_policy
             input:
                 threat_ip: '<% $.threat_ip %>'

--- a/actions/workflows/delete_policy.meta.yaml
+++ b/actions/workflows/delete_policy.meta.yaml
@@ -1,0 +1,24 @@
+---
+version: '2.0'
+
+fortinet.delete_policy:
+    input:
+        - threat_ip
+
+    tasks:
+        delete_policy:
+            action: fortinet.delete_fortinet_policy
+            input:
+                threat_ip: '<% $.threat_ip %>'
+            on-success:
+                - success_msg
+            on-error:
+                - failure_msg
+        success_msg:
+            action: core.local
+            input: 
+                cmd: 'echo \"Successfully excuted action\"'
+        failure_msg:
+            action: core.local
+            input: 
+                cmd: 'echo \"Failed to excute action\"'

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
     - firewalls
     - threat
     - security
-version: 0.0.1
+version: 0.0.2
 author: StackStorm, Inc.
 email: info@stackstorm.com

--- a/rules/create_policy.yaml
+++ b/rules/create_policy.yaml
@@ -1,0 +1,22 @@
+---
+description: Add thread IP to policy table 
+name: create_policy
+pack: fortinet
+ref: fortinet.create_policy
+tags: []
+type:
+  ref: standard
+  parameters:
+enabled: true
+
+trigger:
+  ref: standard
+  type: core.st2.webhook
+  parameters:
+    url: create_policy
+criteria: {}
+action:
+  ref: fortinet.create_policy
+  parameters:
+    threat_ip: '{{trigger.body.threat_ip}}'
+

--- a/rules/delete_policy.yaml
+++ b/rules/delete_policy.yaml
@@ -1,0 +1,23 @@
+---
+description: Delete thread IP from policy table 
+name: delete_policy
+pack: fortinet
+ref: fortinet.delete_policy
+tags: []
+type:
+  ref: standard
+  parameters:
+enabled: true
+
+trigger:
+  ref: standard
+  type: core.st2.webhook
+  parameters:
+    url: delete_policy
+criteria: {}
+action:
+  ref: fortinet.delete_policy
+  parameters:
+    threat_ip: '{{trigger.body.threat_ip}}'
+
+


### PR DESCRIPTION
The st2 Fortinet package is using a newer API.  The firmware running on the FortiManager and 2 FortiGates in RDU are pretty old so it’s not supported.

So create branch for SAN demo to support old version:
1. Added new two new actions create_fortinet_policy and delete_fortinet_policy
2. Because ST2 XMC integration only support ST2 workflows, create new workflows create_policy and delete_policy that calls actions create_fortinet_policy and delete_fortinet_policy
3. All actions are based on Leo Lam's fortinet_policy.py