### PR TITLE
Update "action name" update_address_group.yaml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.0.3
+
+- Update "action name" in update_address_group.yaml
+
 ## v0.0.2
 
 - Minor linting fix

--- a/actions/update_address_group.yaml
+++ b/actions/update_address_group.yaml
@@ -1,4 +1,4 @@
-name: update_address_object
+name: update_address_group_object
 pack: fortinet
 runner_type: python-script
 description: "Update Address Group Details"

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
     - firewalls
     - threat
     - security
-version: 0.0.2
+version: 0.0.3
 author: StackStorm, Inc.
 email: info@stackstorm.com


### PR DESCRIPTION
The "action name" is wrong leading to duplicate "action name" at pack install time.
The new action name is : update_address_group_object, reflection the actual action purpose and content