### PR TITLE
Remove Python 2 tests, and make Python 3 tests required

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,6 @@
 version: 2
 
 jobs:
-  # NOTE: Until we add "python_version" metadata attribute to pack.yaml and
-  # explicitly call which packs work with Python 3.x, Python 3.x failures are
-  # not considered fatal
   build_and_test_python36:
     docker:
       - image: circleci/python:3.6
@@ -24,20 +21,12 @@ jobs:
           key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
       - run:
           name: Download dependencies
-          # NOTE: We don't want to use default "-e" option because this means
-          # step will fail immediately on one of the commands failures and we
-          # can't intercept the error and cause non-fatal exit in case pack
-          # doesn't declare support for Python 3
           shell: /bin/bash
           command: |
             git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
             ~/ci/.circle/dependencies
       - run:
           name: Run tests (Python 3.6)
-          # NOTE: We don't want to use default "-e" option because this means
-          # step will fail immediately on one of the commands failures and we
-          # can't intercept the error and cause non-fatal exit in case pack
-          # doesn't declare support for Python 3
           shell: /bin/bash
           command: ~/ci/.circle/test
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,10 @@ jobs:
           name: Download dependencies
           command: |
             git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
-            ~/ci/.circle/dependencies
+            ~/ci/.circle/dependencies ; ~/ci/.circle/exit_on_py2_checks $?
       - run:
           name: Run tests (Python 2.7)
-          command: ~/ci/.circle/test
+          command: ~/ci/.circle/test ; ~/ci/.circle/exit_on_py2_checks $?
       - save_cache:
           key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
           paths:
@@ -73,7 +73,7 @@ jobs:
           shell: /bin/bash
           command: |
             git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
-            ~/ci/.circle/dependencies ; ~/ci/.circle/exit_on_py3_checks $?
+            ~/ci/.circle/dependencies
       - run:
           name: Run tests (Python 3.6)
           # NOTE: We don't want to use default "-e" option because this means
@@ -81,7 +81,7 @@ jobs:
           # can't intercept the error and cause non-fatal exit in case pack
           # doesn't declare support for Python 3
           shell: /bin/bash
-          command: ~/ci/.circle/test ; ~/ci/.circle/exit_on_py3_checks $?
+          command: ~/ci/.circle/test
       - save_cache:
           key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
           paths:
@@ -119,7 +119,7 @@ workflows:
       - build_and_test_python36
       - deploy:
           requires:
-            - build_and_test_python27
+            - build_and_test_python36
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,10 @@ jobs:
           name: Download dependencies
           command: |
             git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
-            ~/ci/.circle/dependencies ; ~/ci/.circle/exit_on_py2_checks $?
+            ~/ci/.circle/dependencies || ~/ci/.circle/exit_on_py2_checks $?
       - run:
           name: Run tests (Python 2.7)
-          command: ~/ci/.circle/test ; ~/ci/.circle/exit_on_py2_checks $?
+          command: ~/ci/.circle/test || ~/ci/.circle/exit_on_py2_checks $?
       - save_cache:
           key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,48 +1,6 @@
 version: 2
 
 jobs:
-  build_and_test_python27:
-    docker:
-      - image: circleci/python:2.7
-      - image: rabbitmq:3
-      - image: mongo:3.4
-
-    working_directory: ~/repo
-
-    environment:
-      VIRTUALENV_DIR: "~/virtualenv"
-      # Don't install various StackStorm dependencies which are already
-      # installed by CI again in the various check scripts
-      ST2_INSTALL_DEPS: "0"
-
-    steps:
-      - checkout
-      - restore_cache:
-          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
-      - run:
-          name: Download dependencies
-          command: |
-            git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
-            ~/ci/.circle/dependencies || ~/ci/.circle/exit_on_py2_checks $?
-      - run:
-          name: Run tests (Python 2.7)
-          command: ~/ci/.circle/test || ~/ci/.circle/exit_on_py2_checks $?
-      - save_cache:
-          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
-          paths:
-            - ~/.cache/pip
-            - ~/.apt-cache
-      # NOTE: We use virtualenv files from Python 2.7 step in "deploy" job so we
-      # only persist paths from this job
-      - persist_to_workspace:
-          root: /
-          paths:
-            - home/circleci/ci
-            - home/circleci/virtualenv
-            - tmp/st2
-            - home/circleci/repo
-            - home/circleci/.gitconfig
-
   # NOTE: Until we add "python_version" metadata attribute to pack.yaml and
   # explicitly call which packs work with Python 3.x, Python 3.x failures are
   # not considered fatal
@@ -115,7 +73,6 @@ workflows:
   # Workflow which runs on each push
   build_test_deploy_on_push:
     jobs:
-      - build_and_test_python27
       - build_and_test_python36
       - deploy:
           requires:
@@ -125,7 +82,6 @@ workflows:
               only: master
   build_test_weekly:
     jobs:
-      - build_and_test_python27
       - build_and_test_python36
     # Workflow which runs nightly - note we don't perform deploy job on nightly
     # build

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Fortinet Integration Pack
+
 This pack allows you to integrate with
 [Fortinet NGFW](https://www.fortinet.com/products/next-generation-firewall.html).
 
 Here a [demo Fortinet NGFW](https://fortigate.fortidemo.com) provided by Fortinet to try.
+
+**This pack is Python 3 ONLY!**
 
 ## Configuration
 Copy the example configuration in [fortinet.yaml.example](./fortinet.yaml.example) to 


### PR DESCRIPTION
Due to dependencies, this pack is Python 3+ only. So instead of running and then ignoring Python 2 test failures, just run Python 3 tests.