### PR TITLE
Fix deploy using Python 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.6
 
     working_directory: ~/repo
 
@@ -47,11 +47,16 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
+          key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
       - attach_workspace:
           at: /
       - run:
-          name: Install dependencies
+          name: Clone ci repo
+          command: |
+            [[ -d ~/ci ]] || git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
+            ~/ci/.circle/dependencies
+      - run:
+          name: Install apt dependencies
           command: sudo apt -y install gmic optipng
       - run:
           name: Update exchange.stackstorm.org


### PR DESCRIPTION
Previous deployments used the Python 2.7 image and pulled the Python 2.7 cache, which had dependencies already installed.

Now that we removed our Python 2.7 tests, we don't keep that cache around anymore, and dependencies are not available for our deploy step.

Instead, use the Python 3.6 image, and the Python 3.6 cache, and install the dependencies if they're not already installed.

It's a little overengineered in that we reuse the cache (which contains the dependencies) and then possibly install them again. But I intend this to be a blueprint for how we handle deprecating Python 2.7 support in packs in the future.